### PR TITLE
Fix build with cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -std=c99 -O2 -lm")
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 project(amdctl)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic -Wextra -std=c99")
 add_executable(amdctl amdctl.c)
+target_link_libraries(amdctl m)


### PR DESCRIPTION
`target_link_libraries` adds libraries to the end of compilation commands. This fixes linking time errors. 

```
amdctl.c:(.text+0xc37): undefined reference to `pow'
```

Also, I updated the minimum required version of cmake because of warning:

```
CMake Deprecation Warning at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```