### PR TITLE
Detect cores actually present.

### DIFF
--- a/amdctl.c
+++ b/amdctl.c
@@ -197,7 +197,7 @@ void getCpuInfo() {
 	}
 
 	// Check for dual or quad CPU motherboards.
-	unsigned short testcores = (unsigned short) sysconf(_SC_NPROCESSORS_CONF);
+	unsigned short testcores = (unsigned short) sysconf(_SC_NPROCESSORS_ONLN);
 	if (testcores > cores) {
 		if (!quiet) {
 			printf("Multi-CPU motherboard detected: CPU has %d cores, but there is a total %d cores in %d CPU sockets.\n", cores, testcores, testcores / cores);


### PR DESCRIPTION
Encountered errors that this tool is trying read/write msr of non-existence cores.

according to man page of sysconf,
_SC_NPROCESSORS_CONF will report core count that kernel ready to setup
  (including cores not enabled/hot-plugged in),
  which may report more than actual exist.

use _SC_NPROCESSORS_ONLN instead.