### PR TITLE
Allow calling of help on non-AMD cpu's

### DIFF
--- a/amdctl.c
+++ b/amdctl.c
@@ -141,9 +141,9 @@ float getClockSpeed(const unsigned short, const unsigned short);
 void error(const char *);
 
 int main(const int argc, char **argv) {
+	parseOpts(argc, argv);
 	getCpuInfo();
 	checkFamily();
-	parseOpts(argc, argv);
 	if (!quiet) {
 		printf("Detected CPU model %xh, from family %xh with %d CPU cores (REFCLK = %dMHz ; Voltage ID Encodings: %s).\n", cpuModel, cpuFamily, cores, REFCLK, (pvi ? "PVI (parallel)" : "SVI (serial)"));
 		if (nbVid > -1 || cpuVid > -1 || cpuFid > -1 || cpuDid > -1 || togglePs > -1) {


### PR DESCRIPTION
Move the `parseOps` before the CPU checks so that the `--help` command can be executed on non-AMD systems.
This is useful for using `./amdctl --help` as smoke test when building the package in VMs