### PR TITLE
Reduce minimum voltage

### DIFF
--- a/amdctl.c
+++ b/amdctl.c
@@ -88,7 +88,7 @@
 
 #define MAX_VOLTAGE  1550
 #define MID_VOLTAGE  1162.5
-#define MAX_VID      124
+#define MAX_VID      200
 #define MID_VID      63
 #define MIN_VID      32
 #define VID_DIVIDOR1 25


### PR DESCRIPTION
My Ryzen 7 8840HS based laptop (19h) has 3 p-states that have VIDs 151, 171 and 191. The current max of 124 is below all of them. I suggest raising the bar here.